### PR TITLE
Add DAT for Street Hoops

### DIFF
--- a/DAT Files/Street Hoops.dat
+++ b/DAT Files/Street Hoops.dat
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">
+
+<datafile>
+    <header>
+        <name>Street Hoop</name>
+        <description></description>
+        <category></category>
+        <version></version>
+        <date></date>
+        <author></author>
+        <email></email>
+        <homepage>https://store.steampowered.com/app/1189520/Street_Hoop/</homepage>
+        <url>https://store.steampowered.com/app/1189520/Street_Hoop/</url>
+        <comment></comment>
+        <clrmamepro/>
+    </header>
+    <machine name="strhoop">
+        <description>Street Hoop</description>
+        <rom name="sp-s2.sp1" size="131072" crc="9036d879" md5="2968f59f44bf328639aa79391aeeeab4" sha1="4f5ed7105b7128794654ce82b51723e16e389543"/>
+        <rom name="sp-s.sp1" size="131072" crc="c7f2fa45" md5="908b5a0026b2b10f2a7c01ccd98a1236" sha1="09576ff20b4d6b365e78e6a5698ea450262697cd"/>
+        <rom name="sp-45.sp1" size="524288" crc="03cc9f6a" md5="0396470c1ed8b1a7d5cce754924246bb" sha1="cdf1f49e3ff2bac528c21ed28449cf35b7957dc1"/>
+        <rom name="sp-s3.sp1" size="131072" crc="91b64be3" md5="ff453315c5ddacc0f3bf4ca994c13adc" sha1="720a3e20d26818632aedf2c2fd16c54f213543e1"/>
+        <rom name="sp-u2.sp1" size="131072" crc="e72943de" md5="b60fb8ea07e8a64772ab717afba3706d" sha1="5c6bba07d2ec8ac95776aa3511109f5e1e2e92eb"/>
+        <rom name="sp-e.sp1" size="131072" crc="2723a5b5" md5="a7b798c9cafb1aba49090bca34e1d4ec" sha1="5dbff7531cf04886cde3ef022fb5ca687573dcb8"/>
+        <rom name="sp1-u2" size="131072" crc="62f021f4" md5="974fd6936cde3b92c4350235d54156d4" sha1="62d372269e1b3161c64ae21123655a0a22ffd1bb"/>
+        <rom name="sp1-u4.bin" size="131072" crc="1179a30f" md5="4531d7aaa41196dd5e695a86fec621b6" sha1="866817f47aa84d903d0b819d61f6ef356893d16a"/>
+        <rom name="sp1-u3.bin" size="131072" crc="2025b7a2" md5="f6dcf2185162727dda284155868488f3" sha1="73d774746196f377111cd7aa051cc8bb5dd948b3"/>
+        <rom name="vs-bios.rom" size="131072" crc="f0e8f27d" md5="530fb9761957e59aeb47f2e8782df288" sha1="ecf01eda815909f1facec62abf3594eaa8d11075"/>
+        <rom name="sp-j2.sp1" size="131072" crc="acede59c" md5="a51ad226535ff862c1f54120e4298f79" sha1="b6f97acd282fd7e94d9426078a90f059b5e9dd91"/>
+        <rom name="sp1.jipan.1024" size="131072" crc="9fb0abe4" md5="a80fffe27bf8e615171ce728e43d2f6c" sha1="18a987ce2229df79a8cf6a84f968f0e42ce4e59d"/>
+        <rom name="japan-j3.bin" size="131072" crc="dff6d41f" md5="5b2d6f653ba4cf36e7fe237e4acb2f50" sha1="e92910e20092577a4523a6b39d578a71d4de7085"/>
+        <rom name="sp1-j3.bin" size="131072" crc="fbc6d469" md5="1c6314a56d726a0ddf6adb8c35951a36" sha1="46b2b409b5b68869e367b40c846373623edb632a"/>
+        <rom name="sp-j3.sp1" size="524288" crc="486cb450" md5="6bc7cccc88ffcffc8fc18731a06739f3" sha1="52c21ea817928904b80745a8c8d15cbad61e1dc1"/>
+        <rom name="sp-1v1_3db8c.bin" size="131072" crc="162f0ebe" md5="629e6beaa277e039eae2f96ff237f8e6" sha1="fe1c6dd3dfcf97d960065b1bb46c1e11cb7bf271"/>
+        <rom name="uni-bios_3_3.rom" size="131072" crc="24858466" md5="bfc6563dde345d68da2623dc7f0f12d3" sha1="0ad92efb0c2338426635e0159d1f60b4473d0785"/>
+        <rom name="uni-bios_3_2.rom" size="131072" crc="a4e8b9b3" md5="274a7b72b7fd490f1fa71ce32371a93d" sha1="c92f18c3f1edda543d264ecd0ea915240e7c8258"/>
+        <rom name="uni-bios_3_1.rom" size="131072" crc="0c58093f" md5="dd77a172853200bd99c986a48dde914d" sha1="29329a3448c2505e1ff45ffa75e61e9693165153"/>
+        <rom name="uni-bios_3_0.rom" size="131072" crc="4cd01e5f" md5="58dd6648a08dd1b675effd0a5113169a" sha1="b3f6c844542acdae4303ca830def78ffb6b20328"/>
+        <rom name="uni-bios_2_3.rom" size="131072" crc="27664eb5" md5="74c4bb6a945f7284350036b40f0a0d9d" sha1="5b02900a3ccf3df168bdcfc98458136fd2b92ac0"/>
+        <rom name="uni-bios_2_3o.rom" size="131072" crc="601720ae" md5="d9f0ed2e0eeab813c9692d7e8d037fd8" sha1="1b8a72c720cdb5ee3f1d735bbcf447b09204b8d9"/>
+        <rom name="uni-bios_2_2.rom" size="131072" crc="2d50996a" md5="5b9079a81d84137d8b6f221659d777c5" sha1="5241a4fb0c63b1a23fd1da8efa9c9a9bd3b4279c"/>
+        <rom name="uni-bios_2_1.rom" size="131072" crc="8dabf76b" md5="0377c32f69a28f23d9281c448aafb391" sha1="c23732c4491d966cf0373c65c83c7a4e88f0082c"/>
+        <rom name="uni-bios_2_0.rom" size="131072" crc="0c12c2ad" md5="1b9724d1b9d41a1a9b733007b2033fb5" sha1="37bcd4d30f3892078b46841d895a6eff16dc921e"/>
+        <rom name="uni-bios_1_3.rom" size="131072" crc="b24b44a0" md5="856d122ee5fc473d7d1dd99dbf42c25b" sha1="eca8851d30557b97c309a0d9f4a9d20e5b14af4e"/>
+        <rom name="uni-bios_1_2.rom" size="131072" crc="4fa698e9" md5="206fb0d9b5d01a0375d2d3ecab2401b1" sha1="682e13ec1c42beaa2d04473967840c88fd52c75a"/>
+        <rom name="uni-bios_1_2o.rom" size="131072" crc="e19d3ce9" md5="6b2f2d8507be4d1feb14fdfbab0bf22e" sha1="af88ef837f44a3af2d7144bb46a37c8512b67770"/>
+        <rom name="uni-bios_1_1.rom" size="131072" crc="5dda0d84" md5="cafa6c274b271c769b8246c8f87473a1" sha1="4153d533c02926a2577e49c32657214781ff29b7"/>
+        <rom name="uni-bios_1_0.rom" size="131072" crc="0ce453a0" md5="6293999bbc32e594aa0ae1da2113dc4d" sha1="3b4c0cd26c176fc6b26c3a2f95143dd478f6abf9"/>
+        <rom name="079-p1.p1" size="1048576" crc="5e78328e" md5="d4ca07ba5a9eadf8f37698b63769f8a8" sha1="7a00b096ed6dd77afc3008c5a4c83686e475f323"/>
+        <rom name="079-s1.s1" size="131072" crc="3ac06665" md5="11e31ba17b4523968e25f199890fbb9c" sha1="ba9ab51eb95c3568304377ef6d7b5f32e8fbcde1"/>
+        <rom name="sfix.sfix" size="131072" crc="c2ea0cfd" md5="aa2b5d0eae4158ffc0d7d63481c7830b" sha1="fd4a618cdcdbf849374f0a50dd8efe9dbab706c3"/>
+        <rom name="000-lo.lo" size="131072" crc="5a86cff2" md5="fc7599f3f871578fe9a0453662d1c966" sha1="5992277debadeb64d1c1c64b0a92d9293eaf7e4a"/>
+        <rom name="sm1.sm1" size="131072" crc="94416d67" md5="8c26241f9f5beb3a55c8d6ab638d250e" sha1="42f9d7ddd6c0931fd64226a60dc73602b2819dcf"/>
+        <rom name="079-m1.m1" size="131072" crc="bee3455a" md5="d17f2437673102ec937b6b043ee74a5e" sha1="fd5345d9847982085a9b364fff542580889bf02f"/>
+        <rom name="079-v1.v1" size="2097152" crc="718a2400" md5="29584251e26615daeffdc13f2c5081a1" sha1="cefc5d0b302bd4a87ab1fa244ade4482c23c6806"/>
+        <rom name="079-v2.v2" size="1048576" crc="720774eb" md5="4a22e557c6d6230e6eb9384e9d2e408a" sha1="e4926f01322d0a15e700fb150b368152f2091146"/>
+        <rom name="079-c1.c1" size="2097152" crc="0581c72a" md5="964db0953f695b4077b73f96d15d8bb8" sha1="453f7a8474195a1120da5fa24337d79674563d9e"/>
+        <rom name="079-c2.c2" size="2097152" crc="5b9b8fb6" md5="7cad7d763fb8be5957e6b73c2f67c948" sha1="362aa0de0d2cf9aa03758363ffb1e15e046a3930"/>
+        <rom name="079-c3.c3" size="2097152" crc="cd65bb62" md5="a1708f14ece74ffe405ad4b6a7a34e46" sha1="6f47d77d61d4289bcee82df7c4efa5346a6e4c80"/>
+        <rom name="079-c4.c4" size="2097152" crc="a4c90213" md5="529082cf66b19b5657138cbf873e43c2" sha1="1b9f7b5f31acd6df2bdab81b849f32c13aa1b884"/>
+
+        <!-- Not included -->
+        <rom name="uni-bios_4_0.rom" size="131072" crc="a7aab458" sha1="938a0bda7d9a357240718c2cec319878d36b8f72" status="nodump"/>
+    </machine>
+
+    <machine name="additional files">
+        <rom name="000-lo.lo+" size="65536" crc="e09e253c" md5="e255264d85d5765013b1b2fa8109dd53" sha1="2b1c719531dac9bb503f22644e6e4236b91e7cfc"/>
+        <rom name="aes-bios.bin" size="131072" crc="d27a71f1" md5="b11751ad42879c461d64ad2b7b2b0129" sha1="1b3b22092f30c4d1b2c15f04d1670eb1e9fbea07"/>
+        <rom name="ks004-neo-geo.rom" size="131072" crc="0ff83422" md5="3f3b4f6e0a11e5809421c75d80f9aa0e" sha1="dc45a5fc6103addc47eef1d04ecfe567fb77da56"/>
+        <rom name="ks005-neo-geo.rom" size="131072" crc="dc9edbfe" md5="a0c81c04a21dbc84258005eb67b16d50" sha1="bc3bfab784d0864c7e30bbdb96c5cad33ca2cf7c"/>
+        <rom name="ks005b-neo-geo.rom" size="131072" crc="ce60515f" md5="c334c7c1c45f25bc1c589033050d726e" sha1="da28d15b64c72d65edf5cccda8869b793e63d528"/>
+        <rom name="ks020-neo-geo.rom" size="131072" crc="6fd2642d" md5="c5e76e7b51ad085f30c5b8c3a3b3c898" sha1="0669fb6e3c3cfe0def71045bed6fe8b58e410299"/>
+        <rom name="ks030-neo-geo.rom" size="131072" crc="81b29224" md5="f4a5cd48f042389b7e9a5ee5004d8ad0" sha1="5f8c10f4b8f7b96822c806512ca9feefef30be83"/>
+        <rom name="ks040-neo-geo.rom" size="131072" crc="429c5de4" md5="72cd343194b114c7755467780b14b789" sha1="e8314dc0bccd23d65bccfcbbe4356774980a3a0b"/>
+        <rom name="ks045-neo-geo.rom" size="131072" crc="015e77bf" md5="c51f0615b14bfae53fb1f606101a2009" sha1="db8021399b432d992826d4aef00ede6609911c44"/>
+        <rom name="ks046-neo-geo.rom" size="131072" crc="18dacf2b" md5="34ecbd977e29da94f7730ac4479821cf" sha1="a056472ccfe3f3a367f6bd8b0923ecb6b9b15f4b"/>
+        <rom name="neo-epo.bin" size="131072" crc="d27a71f1" md5="b11751ad42879c461d64ad2b7b2b0129" sha1="1b3b22092f30c4d1b2c15f04d1670eb1e9fbea07"/>
+        <rom name="neo-epo.sp1" size="131072" crc="d27a71f1" md5="b11751ad42879c461d64ad2b7b2b0129" sha1="1b3b22092f30c4d1b2c15f04d1670eb1e9fbea07"/>
+        <rom name="NEO-GEO.ROM" size="131072" crc="698ebb7d" md5="3089166a89d9735d038e8e7da36e5bc2" sha1="081c49aa8cc7dad5939833dc1b18338321ea0a07"/>
+        <rom name="neo-geofr.rom" size="131072" crc="d740c343" md5="2c2cd688d53413397fdbb44124325801" sha1="30df0a67275ed1cf7e9817e6943dca98cbec0532"/>
+        <rom name="neo-geopch.rom" size="131072" crc="0fbaa4c7" md5="79ffae46731da9cea9fb0ed68b5e7d8e" sha1="1afa21c56880a56a77f2855d0c93c878788024ba"/>
+        <rom name="neo-po.bin" size="131072" crc="16d0c132" md5="1ec68104095d4b7236e8c18c77ea501b" sha1="4e4a440cae46f3889d20234aebd7f8d5f522e22c"/>
+        <rom name="neo-po.sp1" size="131072" crc="16d0c132" md5="1ec68104095d4b7236e8c18c77ea501b" sha1="4e4a440cae46f3889d20234aebd7f8d5f522e22c"/>
+        <rom name="NEOCD.BIN" size="524288" crc="df9de490" md5="f39572af7584cb5b3f70ae8cc848aba2" sha1="7bb26d1e5d1e930515219cb18bcde5b7b23e2eda"/>
+        <rom name="Neocda.bin" size="131072" crc="9f22676a" md5="997c68f4f29202524817540619542943" sha1="bb4240bac89f836c5631c2dfb367c16796deba34"/>
+        <rom name="neodebug.rom" size="131072" crc="698ebb7d" md5="3089166a89d9735d038e8e7da36e5bc2" sha1="081c49aa8cc7dad5939833dc1b18338321ea0a07"/>
+        <rom name="ng-sm1.rom" size="262144" crc="bddf898f" md5="e609bad33c5eba19cb480e7966c79108" sha1="9451738a1ac6e40194ecd8c037018d4b5f74a2bb"/>
+        <rom name="sfix.sfx" size="131072" crc="354029fc" md5="eba274d931f630efbbf723c19fcd8744" sha1="4ae4bf23b4c2acff875775d4cbff5583893ce2a1"/>
+        <rom name="sfix.sfx+" size="131072" crc="354029fc" md5="eba274d931f630efbbf723c19fcd8744" sha1="4ae4bf23b4c2acff875775d4cbff5583893ce2a1"/>
+        <rom name="uni-bios_1_2crs.rom" size="131072" crc="64b32e54" md5="97d695b3f8c2252151acd934c044245e" sha1="51fad9ac3d1aafd34c531f00243242c7243b827e"/>
+        <rom name="uni-bios_1_3crs.rom" size="131072" crc="2c1cd1ef" md5="f1947d1e898f7549d62510fe296f2764" sha1="e62767909fd582a96212bd56eb4fdf07a91650ad"/>
+        <rom name="uni-bios.rom" size="131072" crc="a97c89a9" md5="727b731c1f4bd643094574ebaa3814b4" sha1="97a5eff3b119062f10e31ad6f04fe4b90d366e7f"/>
+        <rom name="uni-bioses.rom" size="131072" crc="b187ffaf" md5="a59b65dcc58c76482f2285080ef5f732" sha1="5ddf6c5dcc627adad62c361b1beb67a887ddbd19"/>
+        <rom name="uni-biospo.rom" size="131072" crc="0e50b580" md5="5f574a70c47099a647d802d265c83275" sha1="263d1a17347ceacd5e12568b1aae713ad7b3a3f1"/>
+    </machine>
+</datafile>


### PR DESCRIPTION
`strhoop` includes all of the files that MAME 0.285 needs to run. `"uni-bios_4_0.rom"` is not included in any of the Steam files, but does not seem to be required to run the game. The `uni-bios` files from the Zip will need to be renamed to match this DAT.

`additional files` includes all of the other files from the Zip files, but I don't know what they are used for. Hopefully, by including the hashes, somebody else may recognize what these files are for.

#182